### PR TITLE
Fixing Codeforces Time Limit Parsing

### DIFF
--- a/Hightail/src/org/hightail/parsers/task/CodeForcesTaskParser.java
+++ b/Hightail/src/org/hightail/parsers/task/CodeForcesTaskParser.java
@@ -109,7 +109,7 @@ public class CodeForcesTaskParser implements TaskParser {
         // extract time limit
         fb.setFilters(new NodeFilter[] {new CssSelectorNodeFilter("div.time-limit")});
         String timeLimitText = fb.getText(); // should be "time limit per testXXX second"
-        Pattern pattern = Pattern.compile("\\d+");
+        Pattern pattern = Pattern.compile("\\d+(\\.\\d+)?");
         Matcher matcher = pattern.matcher(timeLimitText);
         int timeLimit = Testcase.DEFAULT_TIME_LIMIT;
         if (matcher.find()) {


### PR DESCRIPTION
This pull requests fixes #74 .
The problem was that the regex used for parsing CF time limit considers only the integer part of the time limit. In that problem the time limit was 0.5 seconds so it was parsed as zero seconds which prevents starting the execution of the testcase runner in which the `executionProcess` is initialized, that's why whenever you try to kill this test case a `Null Pointer Exception` occurs.