### PR TITLE
Better debugging support and minor improvements

### DIFF
--- a/Hightail/src/org/hightail/Testcase.java
+++ b/Hightail/src/org/hightail/Testcase.java
@@ -135,10 +135,14 @@ public class Testcase implements Callable<ExecutionResult> {
             InputStream stdout = executionProcess.getInputStream();
             
             // writing input
-            stdin.write(input.getBytes());
-            stdin.flush();
-            stdin.close();
-            
+            try {
+                stdin.write(input.getBytes());
+                stdin.flush();
+                stdin.close();
+            } catch(IOException e) { // stdin has been closed from other end when process has finished already
+                e.printStackTrace();
+            }
+
             // reading stdout
             br = new BufferedReader(new InputStreamReader(stdout));
             sb = new StringBuilder();

--- a/Hightail/src/org/hightail/Testcase.java
+++ b/Hightail/src/org/hightail/Testcase.java
@@ -13,7 +13,6 @@ public class Testcase implements Callable<ExecutionResult> {
     protected String input;
     protected String expectedOutput;
     protected String programOutput = "";
-    protected String programError = "";
     protected int timeLimit = DEFAULT_TIME_LIMIT;
     protected ExecutionResult executionResult = new ExecutionResult();
     protected Process executionProcess;
@@ -127,9 +126,9 @@ public class Testcase implements Callable<ExecutionResult> {
             
             double startTime = Calendar.getInstance().getTimeInMillis();
             // TODO: measure CPU time of executionProcess instead
-            
-            executionProcess = Runtime.getRuntime().exec(getCommandToExecute());
-            
+
+            executionProcess = new ProcessBuilder(getCommandToExecute()).redirectErrorStream(true).start();
+
             OutputStream stdin = executionProcess.getOutputStream();
             InputStream stderr = executionProcess.getErrorStream();
             InputStream stdout = executionProcess.getInputStream();
@@ -157,22 +156,7 @@ public class Testcase implements Callable<ExecutionResult> {
             }
             programOutput = sb.toString();
             br.close();
-            
-            // reading stderr
-            br = new BufferedReader(new InputStreamReader(stderr));
-            sb = new StringBuilder();
-            while ((len = br.read(buf)) != -1 && sb.length() < OUTPUT_MAX_LEN) {
-                sb.append(buf, 0, len);
-            }
-            if (sb.length() >= OUTPUT_MAX_LEN) {
-                executionResult.setResult(ExecutionResultCode.RUNTIME);
-                executionResult.setMsg("Output limit exceeded");
-                killTest();
-                throw new IOException("Output limit exceeded");
-            }
-            programError = sb.toString();
-            br.close();
-            
+
             int execRes = executionProcess.waitFor();
             double endTime = Calendar.getInstance().getTimeInMillis();
             executionResult.setTime((endTime - startTime) / 1000.0);

--- a/Hightail/src/org/hightail/Testcase.java
+++ b/Hightail/src/org/hightail/Testcase.java
@@ -7,8 +7,8 @@ import org.hightail.diff.OutputDiff;
 
 public class Testcase implements Callable<ExecutionResult> {
     public static final int DEFAULT_TIME_LIMIT = 3000; // in milliseconds
-    private static final int OUTPUT_MAX_LEN = 300*1024; // 300 kb
-    
+    private static final int OUTPUT_MAX_LEN = 16*1024*1024; // 16 mb
+
     protected int index = 0;
     protected String input;
     protected String expectedOutput;

--- a/Hightail/src/org/hightail/Testcase.java
+++ b/Hightail/src/org/hightail/Testcase.java
@@ -130,7 +130,6 @@ public class Testcase implements Callable<ExecutionResult> {
             executionProcess = new ProcessBuilder(getCommandToExecute()).redirectErrorStream(true).start();
 
             OutputStream stdin = executionProcess.getOutputStream();
-            InputStream stderr = executionProcess.getErrorStream();
             InputStream stdout = executionProcess.getInputStream();
             
             // writing input

--- a/Hightail/src/org/hightail/diff/OutputDiff.java
+++ b/Hightail/src/org/hightail/diff/OutputDiff.java
@@ -6,66 +6,102 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.round;
 import java.util.StringTokenizer;
+import java.util.Arrays;
 
 public class OutputDiff {
     private static final String format = "expected %s\n"
                         + "received %s";
     private static final double MAX_ACCEPTED_FLOATING_POINT_ERROR = 1e-7;
     public static String diff(String expectedOutput, String actualOutput) {
-        
+
         double maxFloatingPointErrorObtained = 0;
-        
-        StringTokenizer expectedOutputStringTokenizer = new StringTokenizer(expectedOutput),
-                        actualOutputStringTokenizer = new StringTokenizer(actualOutput);
-        
-        while (expectedOutputStringTokenizer.hasMoreTokens() &&
-               actualOutputStringTokenizer.hasMoreTokens()) {
-            
-            String expectedToken = expectedOutputStringTokenizer.nextToken(),
-                   actualToken = actualOutputStringTokenizer.nextToken();
-            
-            if (!expectedToken.equals(actualToken)) {
-                // if they are e.g. 23.0 and 23.1, or 23 and 23.1, or 23.1 and 23, then treat them as floating point
-                if (looksLikeIntegerOrFloatingPoint(expectedToken)
-                        && looksLikeIntegerOrFloatingPoint(actualToken)
-                        && (looksLikeFloatingPoint(expectedToken) || looksLikeFloatingPoint(actualToken))) {
-                    double expectedValue = Double.parseDouble(expectedToken),
-                           actualValue = Double.parseDouble(actualToken);
-                    double absoluteError = abs(expectedValue - actualValue);
-                    double relativeError = abs(expectedValue) > 1e-9 ? absoluteError / abs(expectedValue) : 1e30;
-                    // we consider "absolute or relative precision of at least ..."
-                    double minError = min(absoluteError, relativeError);
-                    if (minError < MAX_ACCEPTED_FLOATING_POINT_ERROR) {
-                        // we let it pass, but update maxFloatingPointErrorObtained
-                        maxFloatingPointErrorObtained = max(maxFloatingPointErrorObtained, minError);
-                    } else {
-                        // too big difference
-                        return String.format(format,
-                                             expectedToken,
-                                             actualToken);
+
+        String[] expectedLines = expectedOutput.split("\n");
+        //TODO inform users that output lines starting with "DBG#~ " are not used for comparision
+        String[] actualLines = Arrays.stream(actualOutput.split("\n")).filter(s -> !s.startsWith("DBG#~ ")).toArray(String[]::new);
+
+        for (int i = 0; i < min(expectedLines.length, actualLines.length); ++i) {
+            StringTokenizer expectedLineStringTokenizer = new StringTokenizer(expectedLines[i]),
+                            actualLineStringTokenizer = new StringTokenizer(actualLines[i]);
+
+            int cntToken = 0;
+
+            while (expectedLineStringTokenizer.hasMoreTokens() &&
+                   actualLineStringTokenizer.hasMoreTokens()) {
+
+                cntToken++;
+
+                String expectedToken = expectedLineStringTokenizer.nextToken(),
+                       actualToken = actualLineStringTokenizer.nextToken();
+
+                if (!expectedToken.equals(actualToken)) {
+                    // if they are e.g. 23.0 and 23.1, or 23 and 23.1, or 23.1 and 23, then treat them as floating point
+                    boolean ok = false;
+                    if (looksLikeIntegerOrFloatingPoint(expectedToken)
+                            && looksLikeIntegerOrFloatingPoint(actualToken)
+                            && (looksLikeFloatingPoint(expectedToken) || looksLikeFloatingPoint(actualToken))) {
+                        double expectedValue = Double.parseDouble(expectedToken),
+                               actualValue = Double.parseDouble(actualToken);
+                        double absoluteError = abs(expectedValue - actualValue);
+                        double relativeError = abs(expectedValue) > 1e-9 ? absoluteError / abs(expectedValue) : 1e30;
+                        // we consider "absolute or relative precision of at least ..."
+                        double minError = min(absoluteError, relativeError);
+                        if (minError < MAX_ACCEPTED_FLOATING_POINT_ERROR) {
+                            // we let it pass, but update maxFloatingPointErrorObtained
+                            maxFloatingPointErrorObtained = max(maxFloatingPointErrorObtained, minError);
+                            ok = true;
+                        }
                     }
-                } else {
+                    if (!ok) {
+                        return "Difference in line " + (i+1) + ", token " + cntToken + ":\n" + String.format(format,
+                                                                                                            expectedToken,
+                                                                                                            actualToken);
+                    }
+                }
+            }
+
+            if (expectedLineStringTokenizer.hasMoreTokens()) {
+                String expectedToken = expectedLineStringTokenizer.nextToken();
+                return "Difference in line " + (i+1) + ":\n" + String.format(format,
+                                                                             expectedToken,
+                                                                             "EOL");
+            }
+
+            if (actualLineStringTokenizer.hasMoreTokens()) {
+                String actualToken = actualLineStringTokenizer.nextToken();
+                return "Difference in line " + (i+1) + ":\n" + String.format(format,
+                                                                             "EOL",
+                                                                             actualToken);
+            }
+        }
+
+
+        if (expectedLines.length > actualLines.length) {
+            for (int i = actualLines.length; i < expectedLines.length; ++i) {
+                StringTokenizer expectedLineStringTokenizer = new StringTokenizer(expectedLines[i]);
+
+                if (expectedLineStringTokenizer.hasMoreTokens()) {
+                    String expectedToken = expectedLineStringTokenizer.nextToken();
                     return String.format(format,
                                          expectedToken,
+                                         "EOF");
+                }
+            }
+        } else if (actualLines.length > expectedLines.length) {
+            for (int i = expectedLines.length; i < actualLines.length; ++i) {
+                StringTokenizer actualLineStringTokenizer = new StringTokenizer(actualLines[i]);
+
+                if (actualLineStringTokenizer.hasMoreTokens()) {
+                    String actualToken = actualLineStringTokenizer.nextToken();
+                    return String.format(format,
+                                         "EOF",
                                          actualToken);
                 }
             }
         }
-        
-        if (expectedOutputStringTokenizer.hasMoreElements()) {
-            String expectedToken = expectedOutputStringTokenizer.nextToken();
-            return String.format(format,
-                                 expectedToken,
-                                 "EOF");
-        }
-        
-        if (actualOutputStringTokenizer.hasMoreElements()) {
-            String actualToken = actualOutputStringTokenizer.nextToken();
-            return String.format(format,
-                                 "EOF",
-                                 actualToken);
-        }
-        
+
+
+
         if (maxFloatingPointErrorObtained != 0) {
             return "OK\n" + "with " + -round(log10(maxFloatingPointErrorObtained)) + " digits of precision";
         } else {

--- a/Hightail/src/org/hightail/ui/MainJFrame.java
+++ b/Hightail/src/org/hightail/ui/MainJFrame.java
@@ -355,7 +355,9 @@ public class MainJFrame extends javax.swing.JFrame {
         java.awt.EventQueue.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new MainJFrame().setVisible(true);
+                MainJFrame mainJFrame = new MainJFrame();
+                mainJFrame.setVisible(true);
+                mainJFrame.setExtendedState(mainJFrame.getExtendedState() | MainJFrame.MAXIMIZED_BOTH);
             }
         });
     }

--- a/Hightail/src/org/hightail/ui/MultilineTableCellRenderer.java
+++ b/Hightail/src/org/hightail/ui/MultilineTableCellRenderer.java
@@ -44,7 +44,7 @@ implements TableCellRenderer {
             setForeground(table.getForeground());
             setBackground(table.getBackground());
         }
-        setFont(table.getFont());
+        setFont(new java.awt.Font("Monospaced", 0, 12));
         if (hasFocus) {
             setBorder(UIManager.getBorder("Table.focusCellHighlightBorder"));
             if (table.isCellEditable(row, column)) {

--- a/Hightail/src/org/hightail/ui/ProblemJPanel.java
+++ b/Hightail/src/org/hightail/ui/ProblemJPanel.java
@@ -334,7 +334,8 @@ public class ProblemJPanel extends javax.swing.JPanel implements TestingListener
         if (isTesting) {
             return;
         }
-        Testcase newTestcase = new Testcase();
+        Testcase newTestcase = new Testcase("", "", problem.getTestcaseSet().isEmpty() ? Testcase.DEFAULT_TIME_LIMIT :
+                                                                                         problem.getTestcase(0).getTimeLimit());
         TestcaseJDialog dialog = new TestcaseJDialog(parentWindow, newTestcase, true);
         dialog.setVisible(true); // this is modal; it will block until window is closed
         if (dialog.getReturnValue()) {

--- a/Hightail/src/org/hightail/ui/TestcaseJDialog.form
+++ b/Hightail/src/org/hightail/ui/TestcaseJDialog.form
@@ -155,7 +155,7 @@
           <Properties>
             <Property name="columns" type="int" value="20"/>
             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-              <Font name="Courier New" size="13" style="0"/>
+              <Font name="Monospaced" size="12" style="0"/>
             </Property>
             <Property name="rows" type="int" value="5"/>
             <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
@@ -176,7 +176,7 @@
           <Properties>
             <Property name="columns" type="int" value="20"/>
             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-              <Font name="Courier New" size="13" style="0"/>
+              <Font name="Monospaced" size="12" style="0"/>
             </Property>
             <Property name="rows" type="int" value="5"/>
             <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
@@ -198,7 +198,7 @@
             <Property name="editable" type="boolean" value="false"/>
             <Property name="columns" type="int" value="20"/>
             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-              <Font name="Courier New" size="13" style="0"/>
+              <Font name="Monospaced" size="12" style="0"/>
             </Property>
             <Property name="rows" type="int" value="5"/>
             <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">

--- a/Hightail/src/org/hightail/ui/TestcaseJDialog.java
+++ b/Hightail/src/org/hightail/ui/TestcaseJDialog.java
@@ -174,20 +174,20 @@ public class TestcaseJDialog extends javax.swing.JDialog {
         jLabel5.setText("Input:");
 
         inputTextarea.setColumns(20);
-        inputTextarea.setFont(new java.awt.Font("Courier New", 0, 13)); // NOI18N
+        inputTextarea.setFont(new java.awt.Font("Monospaced", 0, 12)); // NOI18N
         inputTextarea.setRows(5);
         inputTextarea.setMargin(new java.awt.Insets(3, 3, 3, 3));
         jScrollPane2.setViewportView(inputTextarea);
 
         expectedOutputTextarea.setColumns(20);
-        expectedOutputTextarea.setFont(new java.awt.Font("Courier New", 0, 13)); // NOI18N
+        expectedOutputTextarea.setFont(new java.awt.Font("Monospaced", 0, 12)); // NOI18N
         expectedOutputTextarea.setRows(5);
         expectedOutputTextarea.setMargin(new java.awt.Insets(3, 3, 3, 3));
         jScrollPane1.setViewportView(expectedOutputTextarea);
 
         programOutputTextarea.setEditable(false);
         programOutputTextarea.setColumns(20);
-        programOutputTextarea.setFont(new java.awt.Font("Courier New", 0, 13)); // NOI18N
+        programOutputTextarea.setFont(new java.awt.Font("Monospaced", 0, 12)); // NOI18N
         programOutputTextarea.setRows(5);
         programOutputTextarea.setMargin(new java.awt.Insets(3, 3, 3, 3));
         jScrollPane3.setViewportView(programOutputTextarea);

--- a/Hightail/src/org/hightail/ui/TestcaseJDialog.java
+++ b/Hightail/src/org/hightail/ui/TestcaseJDialog.java
@@ -1,6 +1,8 @@
 package org.hightail.ui;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.KeyboardFocusManager;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import javax.swing.AbstractAction;
@@ -72,6 +74,9 @@ public class TestcaseJDialog extends javax.swing.JDialog {
         inputTextarea.getDocument().addDocumentListener(documentListener);
         expectedOutputTextarea.getDocument().addDocumentListener(documentListener);
         timeLimitTextField.getDocument().addDocumentListener(documentListener);
+
+        Rectangle bounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+        this.setBounds(bounds);
     }
     
     private void makeShortcuts() {


### PR DESCRIPTION
Changes:

- show line and token number of 1st mismatch, Attempts to fix #5 .
- redirect stderr to stdout
- exclude lines starting with "DBG#~ ". Attempts to fix #29  (__TODO__: inform users about it)
- set new testcase time limit from 1st testcase instead of default
- catch IOException separately when writing input ("Broken pipe" or "Stream closed" error occurs frequently when program doesn't process whole input, especially when input is large. Before this change, those were uncaught and program was unnecessarily stuck.)
- Increase max output length from 300 kb to 16 mb
- Start maximized
- Monospace font (grid problems are hard to visualize with non-monospace font)